### PR TITLE
Fixing Windows R Download Link

### DIFF
--- a/RHelp.Rmd
+++ b/RHelp.Rmd
@@ -25,7 +25,7 @@ We will use [RStudio](https://www.rstudio.com/products/rstudio/download/) for al
     <td style="padding:5px;">
 **First**, install:
     </td><td style="padding:5px;">
-<img src="./Images/R_logo.jpeg" alt="R_logo.jpg" width="64" height="49" />&nbsp;(<a href="https://cran.r-project.org/bin/macosx/base/R-4.1.0.pkg" target="_blank">Mac OS X</a> | <a href="https://cran.r-project.org/bin/windows/base/R-4.0.5-win.exe" target="_blank">Windows</a>),
+<img src="./Images/R_logo.jpeg" alt="R_logo.jpg" width="64" height="49" />&nbsp;(<a href="https://cran.r-project.org/bin/macosx/base/R-4.1.0.pkg" target="_blank">Mac OS X</a> | <a href="https://cran.r-project.org/bin/windows/base/release.html" target="_blank">Windows</a>),
     </td>
   </tr><tr>
     <td style="padding:5px;">
@@ -61,7 +61,7 @@ To install the statistical analysis program **RStudio** you will first need to i
     <td style="padding:5px;">
 Install the R Software by clicking here:
     </td><td style="padding:5px;">
-<img src="./Images/R_logo.jpeg" alt="R_logo.jpg" width="64" height="49" />&nbsp;(<a href="https://cran.r-project.org/bin/macosx/R-4.0.5.pkg" target="_blank">Mac OS X</a> | <a href="https://cran.r-project.org/bin/windows/base/R-4.0.5-win.exe" target="_blank">Windows</a>),
+<img src="./Images/R_logo.jpeg" alt="R_logo.jpg" width="64" height="49" />&nbsp;(<a href="https://cran.r-project.org/bin/macosx/R-4.0.5.pkg" target="_blank">Mac OS X</a> | <a href="https://cran.r-project.org/bin/windows/base/release.html" target="_blank">Windows</a>),
     </td>
   </tr>
 </table>

--- a/docs/RHelp.html
+++ b/docs/RHelp.html
@@ -471,7 +471,7 @@ div.tocify {
 <strong>First</strong>, install:
 </td>
 <td style="padding:5px;">
-<img src="Images/R_logo.jpeg" alt="R_logo.jpg" width="64" height="49" /> (<a href="https://cran.r-project.org/bin/macosx/base/R-4.1.0.pkg" target="_blank">Mac OS X</a> | <a href="https://cran.r-project.org/bin/windows/base/R-4.0.5-win.exe" target="_blank">Windows</a>),
+<img src="Images/R_logo.jpeg" alt="R_logo.jpg" width="64" height="49" /> (<a href="https://cran.r-project.org/bin/macosx/base/R-4.1.0.pkg" target="_blank">Mac OS X</a> | <a href="https://cran.r-project.org/bin/windows/base/release.html" target="_blank">Windows</a>),
 </td>
 </tr>
 <tr>
@@ -504,7 +504,7 @@ div.tocify {
 Install the R Software by clicking here:
 </td>
 <td style="padding:5px;">
-<img src="Images/R_logo.jpeg" alt="R_logo.jpg" width="64" height="49" /> (<a href="https://cran.r-project.org/bin/macosx/R-4.0.5.pkg" target="_blank">Mac OS X</a> | <a href="https://cran.r-project.org/bin/windows/base/R-4.0.5-win.exe" target="_blank">Windows</a>),
+<img src="Images/R_logo.jpeg" alt="R_logo.jpg" width="64" height="49" /> (<a href="https://cran.r-project.org/bin/macosx/R-4.0.5.pkg" target="_blank">Mac OS X</a> | <a href="https://cran.r-project.org/bin/windows/base/release.html" target="_blank">Windows</a>),
 </td>
 </tr>
 </table>


### PR DESCRIPTION
In the last fix I broke the working link instead of fixing the broken link. Now I have fixed both links to get the most recent Windows release of R.